### PR TITLE
OPENEUROPA-632: Add minimum stability to drupal core.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "nikic/php-parser": "~3",
         "openeuropa/code-review": "^0.2",
         "openeuropa/task-runner": "^0.7",
-        "webflo/drupal-core-require-dev": "~8.6"
+        "webflo/drupal-core-require-dev": "~8.6@alpha"
     },
     "scripts": {
         "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.1",
-        "drupal/core": "~8.6",
+        "drupal/core": "~8.6@alpha",
         "openeuropa/pcas": "dev-master",
         "php-http/guzzle6-adapter": "^1.1"
     },


### PR DESCRIPTION
## OPENEUROPA-632

### Description

Upgrade minimum stability of drupal core to use alpha versions whenever they are ready and avoid using dev versions.

### Change log

- Changed: Add alpha minimum stability to drupal core